### PR TITLE
Add XCFLAGS for dhrystone, the same optimization flags in coremark.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,15 @@
 DHRY-LFLAGS =
 
-DHRY-CFLAGS := -O3 -DTIME -DNOENUM -Wno-implicit -mexplicit-relocs -save-temps
-DHRY-CFLAGS += -fno-inline -fno-builtin-printf -fno-common -falign-functions=4 
+DHRY-CFLAGS := -O3 -DTIME -DNOENUM -Wno-implicit -save-temps
+DHRY-CFLAGS += -fno-builtin-printf -fno-common -falign-functions=4
+
 #Uncomment below for FPGA run, default DHRY_ITERS is 2000 for RTL
-#DHRY-CFLAGS += -DDHRY_ITERS=2000000
+#DHRY-CFLAGS += -DDHRY_ITERS=20000000
 
 SRC = dhry_1.c dhry_2.c
 HDR = dhry.h
 
-override CFLAGS += $(DHRY-CFLAGS) -Xlinker --defsym=__stack_size=0x800
+override CFLAGS += $(DHRY-CFLAGS) $(XCFLAGS) -Xlinker --defsym=__stack_size=0x800
 dhrystone: $(SRC) $(HDR)
 	$(CC) $(CFLAGS) $(SRC) $(LDFLAGS) $(LOADLIBES) $(LDLIBS) -o $@
 


### PR DESCRIPTION
Increase the iteration count becouse the time percision is only s not ms.

Move optimization flags to freedom-e-sdk.