### PR TITLE
Perform a two-stage link to rename benchmark .text sections to .itim

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,29 @@ DHRY-CFLAGS += -fno-builtin-printf -fno-common -falign-functions=4
 #DHRY-CFLAGS += -DDHRY_ITERS=20000000
 
 SRC = dhry_1.c dhry_2.c strcmp.S
+OBJS = dhry_1.o dhry_2.o strcmp.o
 HDR = dhry.h
 
+ifeq ($(findstring rv32,$(RISCV_ARCH)),rv32)
+RISCV_LD_EMULATION = elf32lriscv
+else
+RISCV_LD_EMULATION = elf64lriscv
+endif
+
 override CFLAGS += $(DHRY-CFLAGS) $(XCFLAGS) -Xlinker --defsym=__stack_size=0x800 -Xlinker --defsym=__heap_size=0x1000
-dhrystone: $(SRC) $(HDR)
-	$(CC) $(CFLAGS) $(SRC) $(LDFLAGS) $(LOADLIBES) $(LDLIBS) -o $@
+
+# Perform an incremental link on object files to move .text sections into .itim so that benchmark code
+# gets placed in Instruction Tightly-Integrated Memory (ITIM) if one exists.
+%.o: $.o.unrenamed move-text-to-itim.lds
+	$(LD) -i -m $(RISCV_LD_EMULATION) -T move-text-to-itim.lds $< -o $@
+
+%.o.unrenamed: %.S $(HDR)
+%.o.unrenamed: %.c $(HDR)
+	$(CC) $(CFLAGS) -c $< -o $@.unrenamed
+
+dhrystone: $(OBJS)
+	$(CC) $(CFLAGS) $(LDFLAGS) $(LOADLIBES) $(LDLIBS) $^ -o $@
 
 clean:
-	rm -f *.i *.s *.o dhrystone dhrystone.hex
+	rm -f *.i *.s *.o *.unrenamed dhrystone dhrystone.hex
 

--- a/move-text-to-itim.lds
+++ b/move-text-to-itim.lds
@@ -1,0 +1,6 @@
+SECTIONS
+{
+        .itim : {
+                *(.text .text.*)
+        }
+}


### PR DESCRIPTION
So I had an idea yesterday and wanted to propose this as a way to improve how we handle putting hot benchmark code into the ITIM.

Right now, the "ramrodata" linker scripts we generate place all (non-startup) .text sections into the .itim section if the ITIM is above a certain size so that we can improve instruction fetch for hot benchmark code. This has the downside of pulling a ton of unnecessary code into the ITIM, which is often not all that big.

If instead we perform a two-stage link in our benchmarks, we can mark only the benchmark code as destined for the ITIM and be a lot more efficient about our allocation. This would improve benchmark scores on a lot of designs which have small ITIMs. This PR is my proposal for how to do this from the benchmark side, but there's a few more minor changes needed across the rest of freedom-e-sdk.

One risk is that the benchmark depends on code in, say, libc, like Dhrystone does here. Since I know @keith-packard has objected (reasonably) to having a copy of strcmp here in Dhrystone, this is probably the biggest problem with my approach here.